### PR TITLE
Add minor movement resistance to leaves

### DIFF
--- a/mods/asuna/asuna_leaves/init.lua
+++ b/mods/asuna/asuna_leaves/init.lua
@@ -3,6 +3,7 @@ for node,def in pairs(minetest.registered_nodes) do
 	if def.groups and def.groups.leaves then
 		minetest.override_item(node,{
 			walkable = false,
+			move_resistance = 1,
 		})
 	end
 end


### PR DESCRIPTION
Although leaves are thematically a tangible kind of node, Asuna makes all leaves non-colliding as a way to facilitate travel in dense forests. Adding the smallest possible movement resistance to slow players down as they move through leaves will make leaves feel slightly more substantial. This will have a few side effects:

- Jumping while standing in leaves will reduce the jump to less than one node of height
- Falling through leaves will reduce falling momentum which will in turn reduce falling damage
- Movement resistance will only apply to players with leaves at their feet and not to players walking through leaves at head level

In total, this change will add some flavor and function to leaves while keeping them as unobtrusive as possible.