### PR TITLE
Fix crash when manipulating Japanese walls in certain ways

### DIFF
--- a/mods/biomes/japaneseforest/depends.txt
+++ b/mods/biomes/japaneseforest/depends.txt
@@ -5,3 +5,4 @@ bambooforest
 ethereal
 moreblocks?
 bonemeal?
+xpanes

--- a/mods/biomes/japaneseforest/nodes.lua
+++ b/mods/biomes/japaneseforest/nodes.lua
@@ -136,7 +136,7 @@ doors.register("japanese_door", {
 		}
 })
 
-xpanes.register_pane("japaneseforest:japanese_small_wall_flat", {
+xpanes.register_pane("japanese_small_wall", {
 	description = "Japanese Small Wall",
 	textures = {"small_wall.png", "", "side_small_wall.png"},
 	inventory_image = "small_wall.png",


### PR DESCRIPTION
When a Japanese wall is connected to a node at a 90° angle and the node it's connected to is dug/broken, the game will crash. This was due to the wall's name registered ending with `_flat` which is treated specially in the xpanes internal functions. Renaming the wall node fixes the crash.