### PR TITLE
Fix soup recipes and keep bowl when consumed

### DIFF
--- a/mods/soup/init.lua
+++ b/mods/soup/init.lua
@@ -2,19 +2,19 @@
 minetest.register_craftitem("soup:tomato_soup", {
     description = "Tomato Soup",
     inventory_image = "tomato_soup.png",
-    on_use = minetest.item_eat(5),
+    on_use = minetest.item_eat(5,"ethereal:bowl"),
 })
 
 minetest.register_craftitem("soup:mushroom_soup", {
     description = "Mushroom Soup",
     inventory_image = "mushroom_soup.png",
-    on_use = minetest.item_eat(5),
+    on_use = minetest.item_eat(5,"ethereal:bowl"),
 })
 
 minetest.register_craftitem("soup:chicken_noodle_soup", {
     description = "Chicken Noodle Soup",
     inventory_image = "chicken_noodle_soup.png",
-    on_use = minetest.item_eat(8),
+    on_use = minetest.item_eat(8,"ethereal:bowl"),
 })
 
 -- Soup recipes
@@ -30,7 +30,7 @@ minetest.register_craft({
 minetest.register_craft({
 	output = "soup:mushroom_soup",
 	recipe = {
-		{"group:mushroom_food","group:mushroom_food", "group:mushroom_food"},
+		{"group:food_mushroom","group:food_mushroom", "group:food_mushroom"},
 		{"","bottles:bottle_of_water", ""},
 		{"","group:food_bowl", ""}
 	}


### PR DESCRIPTION
The mushroom soup previously used an erroneous item group, and bowls are now preserved after soup is consumed. This will ensure the proper behavior of mod soup.