### PR TITLE
Fix the name of the Zaida flower in asuna_core/decor.lua

### DIFF
--- a/mods/asuna/asuna_core/decor.lua
+++ b/mods/asuna/asuna_core/decor.lua
@@ -45,7 +45,7 @@ local flower_colors = {
 		"beautiflowers:victoria",
 		"beautiflowers:virginia",
 		"beautiflowers:xenia",
-		"beautiflowers:zadia",
+		"beautiflowers:zaida",
 	},
 	orange = {
 		"beautiflowers:dafne",


### PR DESCRIPTION
The name of the Zaida flower was incorrectly spelled as `beautiflowers:zadia` in asuna_core/decor.lua which caused it not to spawn in nature.