### PR TITLE
biomes: fix sapling growth

### DIFF
--- a/mods/biomes/badland/nodes.lua
+++ b/mods/biomes/badland/nodes.lua
@@ -1,3 +1,17 @@
+local modpath = minetest.get_modpath("badland")
+
+
+local function grow_new_badland_tree(pos)
+	if not default.can_grow(pos) then
+		-- try a bit later again
+			minetest.get_node_timer(pos):start(math.random(300, 1500))
+		return
+	end
+	minetest.remove_node(pos)
+	minetest.place_schematic({x = pos.x-1, y = pos.y, z = pos.z-1}, modpath.."/schematics/badland_tree_1.mts", "0", nil, false)
+end
+
+
 minetest.register_node("badland:badland_grass", {
 	description = "Badland Grass",
 	tiles = {"badland_grass.png", "default_dirt.png",
@@ -303,16 +317,4 @@ if minetest.get_modpath("bonemeal") ~= nil then
 bonemeal:add_sapling({
 	{"badland:badland_sapling", grow_new_badland_tree, "soil"},
 })
-end
-
-
-
-local function grow_new_badland_tree(pos)
-	if not default.can_grow(pos) then
-		-- try a bit later again
-			minetest.get_node_timer(pos):start(math.random(300, 1500))
-		return
-	end
-	minetest.remove_node(pos)
-	minetest.place_schematic({x = pos.x-1, y = pos.y, z = pos.z-1}, modpath.."/schematics/badland_tree_1.mts", "0", nil, false)
 end

--- a/mods/biomes/frost_land/nodes.lua
+++ b/mods/biomes/frost_land/nodes.lua
@@ -1,3 +1,17 @@
+local modpath = minetest.get_modpath("frost_land")
+
+
+local function grow_new_frost_land_tree(pos)
+	if not default.can_grow(pos) then
+		-- try a bit later again
+			minetest.get_node_timer(pos):start(math.random(300, 1500))
+		return
+	end
+	minetest.remove_node(pos)
+	minetest.place_schematic({x = pos.x-1, y = pos.y, z = pos.z-1}, modpath.."/schematics/frost_tree_1.mts", "0", nil, false)
+end
+
+
 minetest.register_node("frost_land:frost_land_leaves_1", {
 	description = "frost_land Blue Leaves",
 	drawtype = "allfaces_optional",
@@ -111,16 +125,4 @@ if minetest.get_modpath("bonemeal") ~= nil then
 bonemeal:add_sapling({
 	{"frost_land:frost_land_sapling", grow_new_frost_land_tree, "soil"},
 })
-end
-
-
-
-local function grow_new_frost_land_tree(pos)
-	if not default.can_grow(pos) then
-		-- try a bit later again
-			minetest.get_node_timer(pos):start(math.random(300, 1500))
-		return
-	end
-	minetest.remove_node(pos)
-	minetest.place_schematic({x = pos.x-1, y = pos.y, z = pos.z-1}, modpath.."/schematics/frost_tree_1.mts", "0", nil, false)
 end

--- a/mods/biomes/japaneseforest/tree.lua
+++ b/mods/biomes/japaneseforest/tree.lua
@@ -1,38 +1,3 @@
--------------Sapling
-minetest.register_node("japaneseforest:japanese_sapling", {
-	description = "Japanese Sapling",
-	drawtype = "plantlike",
-	tiles = {"japanese_sapling.png"},
-	inventory_image = "japanese_sapling.png",
-	on_use = minetest.item_eat(2),
-	wield_image = "japanese_sapling.png",
-	paramtype = "light",
-	sunlight_propagates = true,
-	walkable = false,
-	on_timer = grow_new_japanese_tree,
-	selection_box = {
-		type = "fixed",
-		fixed = {-4 / 16, -0.5, -4 / 16, 4 / 16, 7 / 16, 4 / 16}
-	},
-	groups = {snappy = 2, dig_immediate = 3, flammable = 2,
-		attached_node = 1, sapling = 1, food_bread = 1},
-	sounds = default.node_sound_leaves_defaults(),
-
-	on_construct = function(pos)
-		minetest.get_node_timer(pos):start(math.random(300, 1500))
-	end,
-
-	on_place = function(itemstack, placer, pointed_thing)
-		itemstack = default.sapling_on_place(itemstack, placer, pointed_thing,
-			"japaneseforest:japanese_sapling",
-			{x = -2, y = 1, z = -2},
-			{x = 2, y = 15, z = 2},
-			4)
-
-		return itemstack
-	end,
-})
-
 local function grow_new_japanese_tree(pos)
 	if not default.can_grow(pos) then
 		-- try a bit later again
@@ -92,3 +57,38 @@ function grow_new_japanese_tree_3(pos)
 end
     end
 end
+
+-------------Sapling
+minetest.register_node("japaneseforest:japanese_sapling", {
+	description = "Japanese Sapling",
+	drawtype = "plantlike",
+	tiles = {"japanese_sapling.png"},
+	inventory_image = "japanese_sapling.png",
+	on_use = minetest.item_eat(2),
+	wield_image = "japanese_sapling.png",
+	paramtype = "light",
+	sunlight_propagates = true,
+	walkable = false,
+	on_timer = grow_new_japanese_tree,
+	selection_box = {
+		type = "fixed",
+		fixed = {-4 / 16, -0.5, -4 / 16, 4 / 16, 7 / 16, 4 / 16}
+	},
+	groups = {snappy = 2, dig_immediate = 3, flammable = 2,
+		attached_node = 1, sapling = 1, food_bread = 1},
+	sounds = default.node_sound_leaves_defaults(),
+
+	on_construct = function(pos)
+		minetest.get_node_timer(pos):start(math.random(300, 1500))
+	end,
+
+	on_place = function(itemstack, placer, pointed_thing)
+		itemstack = default.sapling_on_place(itemstack, placer, pointed_thing,
+			"japaneseforest:japanese_sapling",
+			{x = -2, y = 1, z = -2},
+			{x = 2, y = 15, z = 2},
+			4)
+
+		return itemstack
+	end,
+})

--- a/mods/biomes/nightshade/nodes.lua
+++ b/mods/biomes/nightshade/nodes.lua
@@ -1,3 +1,17 @@
+local modpath = minetest.get_modpath("nightshade")
+
+
+local function grow_new_nightshade_tree(pos)
+	if not default.can_grow(pos) then
+		-- try a bit later again
+			minetest.get_node_timer(pos):start(math.random(300, 1500))
+		return
+	end
+	minetest.remove_node(pos)
+	minetest.place_schematic({x = pos.x-1, y = pos.y, z = pos.z-1}, modpath.."/schematics/nightshade_tree_1.mts", "0", nil, false)
+end
+
+
 minetest.register_node("nightshade:nightshade_dirt_with_grass", {
 	description = "NightShade Dirt With Grass",
 	tiles = {"nightshade_nightshade_grass.png", "default_dirt.png",
@@ -204,16 +218,4 @@ if minetest.get_modpath("bonemeal") ~= nil then
 bonemeal:add_sapling({
 	{"nightshade:nightshade_sapling", grow_new_nightshade_tree, "soil"},
 })
-end
-
-
-
-local function grow_new_nightshade_tree(pos)
-	if not default.can_grow(pos) then
-		-- try a bit later again
-			minetest.get_node_timer(pos):start(math.random(300, 1500))
-		return
-	end
-	minetest.remove_node(pos)
-	minetest.place_schematic({x = pos.x-1, y = pos.y, z = pos.z-1}, modpath.."/schematics/nightshade_tree_1.mts", "0", nil, false)
 end


### PR DESCRIPTION
grow_new_* functions were defined after the register_node("..._sapling", ...) calls, so on_timer were assigned nil functions, making them fail silently.

Does not fix issue #55. Other mod(pack)s are unaffected.