### PR TITLE
Render leaves in Ethereal biomes as cubic

### DIFF
--- a/mods/ethereal/init.lua
+++ b/mods/ethereal/init.lua
@@ -32,7 +32,7 @@ end
 
 -- DO NOT change settings below, use the settings.conf file instead
 
-setting("number", "leaftype", 0)
+setting("number", "leaftype", 1)
 setting("bool", "leafwalk", false)
 setting("bool", "cavedirt", true)
 setting("bool", "torchdrop", true)

--- a/mods/ethereal/leaves.lua
+++ b/mods/ethereal/leaves.lua
@@ -2,14 +2,9 @@
 local S = ethereal.intllib
 
 
--- set leaftype (value inside init.lua)
-local leaftype = "plantlike"
-local leafscale = 1.4
-
-if ethereal.leaftype ~= 0 then
-	leaftype = "allfaces_optional"
-	leafscale = 1.0
-end
+-- set leaftype (ignores value inside init.lua)
+leaftype = "allfaces_optional"
+leafscale = 1.0
 
 -- default apple tree leaves
 minetest.override_item("default:leaves", {

--- a/mods/ethereal/settingtypes.txt
+++ b/mods/ethereal/settingtypes.txt
@@ -1,4 +1,4 @@
-ethereal.leaftype (0 for 2D plantlike leaves or 1 for 3D) int 0
+ethereal.leaftype (0 for 2D plantlike leaves or 1 for 3D) int 1
 ethereal.leafwalk (Walkable leaves) bool false
 
 ethereal.cavedirt (Caves cut through dirt) bool true


### PR DESCRIPTION
The `leaftype` setting defaults to `0` which renders Ethereal leaves as `plantlike`. It is preferable that these leaves render as cubic instead of like plants.