### PR TITLE
Disallow incompatible mapgen v6

### DIFF
--- a/game.conf
+++ b/game.conf
@@ -1,4 +1,4 @@
 title       = Asuna
 author      = EmptyStar
 description = A vibrant world of natural wonders
-disallowed_mapgens = v6,flat
+disallowed_mapgens = v6

--- a/game.conf
+++ b/game.conf
@@ -1,3 +1,4 @@
 title       = Asuna
 author      = EmptyStar
 description = A vibrant world of natural wonders
+disallowed_mapgens = v6,flat


### PR DESCRIPTION
Mapgen v6 does not spawn Asuna biomes properly and is thus unsuitable. Flat mapgen was originally slated for removal, but it actually spawns most biomes properly. Closes #72.