### PR TITLE
Animalia compatibility and spawning rules

### DIFF
--- a/mods/animalia/api/api.lua
+++ b/mods/animalia/api/api.lua
@@ -585,7 +585,7 @@ function animalia.register_biome_group(name, def)
 	animalia.registered_biome_groups[name].biomes = {}
 end
 
---[[local function assign_biome_group(name)
+local function assign_biome_group(name)
 	local def = minetest.registered_biomes[name]
 	local turf = def.node_top
 	local heat = def.heat_point or 0
@@ -696,4 +696,4 @@ animalia.register_biome_group("common", {
 	min_humidity = 20,
 	max_humidity = 80,
 	min_height = 1
-})]]
+})

--- a/mods/animalia/api/spawning.lua
+++ b/mods/animalia/api/spawning.lua
@@ -10,9 +10,9 @@ local pest_spawn_chance = tonumber(minetest.settings:get("animalia_pest_chance")
 
 local predator_spawn_chance = tonumber(minetest.settings:get("animalia_predator_chance")) or 30000
 
--- Get Biomes --
+-- Get Biomes -- already happens via Asuna/biomes.lua
 
-local chicken_biomes = {}
+--[[local chicken_biomes = {}
 
 local frog_biomes = {}
 
@@ -24,7 +24,7 @@ local function insert_all(tbl, tbl2)
 	end
 end
 
---[[minetest.register_on_mods_loaded(function()
+minetest.register_on_mods_loaded(function()
 	insert_all(chicken_biomes, animalia.registered_biome_groups["grassland"].biomes)
 	insert_all(chicken_biomes, animalia.registered_biome_groups["tropical"].biomes)
 	insert_all(pig_biomes, animalia.registered_biome_groups["temperate"].biomes)
@@ -215,16 +215,18 @@ creatura.register_abm_spawn("animalia:frog", {
 	max_height = 8,
 	min_group = 2,
 	max_group = 4,
+	biomes = asuna.features.animals.frog,
 	neighbors = {"group:water"},
 	nodes = {"group:soil"}
 })
 
 creatura.register_abm_spawn("animalia:tropical_fish", {
 	chance = ambient_spawn_chance,
-	min_height = -128,
+	min_height = -35,
 	max_height = 1,
 	min_group = 6,
 	max_group = 12,
+	biomes = asuna.features.animals.tropical_fish,
 	nodes = {"group:water"},
 	neighbors = {"group:coral"}
 })


### PR DESCRIPTION
Enable animalia.registered_biome_groups for compatibility with dependent mods, and add biome spawning rules for frog and tropical fish.